### PR TITLE
require 'under_fire/version' in client

### DIFF
--- a/lib/under_fire/client.rb
+++ b/lib/under_fire/client.rb
@@ -4,6 +4,7 @@ require 'under_fire/album_fetch'
 require 'under_fire/api_request'
 require 'under_fire/api_response'
 require 'under_fire/configuration'
+require 'under_fire/version'
 
 require 'pry'
 


### PR DESCRIPTION
Fixes the `NameError` thrown in the current live version (0.7.0) of the gem if you require `under_fire/client` when using the gem as described in docs.
